### PR TITLE
tests(reworkTestOrganization): add a commons module to extract some functions

### DIFF
--- a/test/commons.ml
+++ b/test/commons.ml
@@ -1,0 +1,52 @@
+(** Utils function shared by the different tests modules *)
+module Commons = struct
+  open Bin_prot.Std
+  open Pollinate
+
+  type request =
+    | Ping
+    | Get
+    | Insert of string
+  [@@deriving bin_io, show { with_path = false }]
+
+  type response =
+    | Pong
+    | List    of string list
+    | Success of string
+    | Error   of string
+  [@@deriving bin_io, show { with_path = false }]
+
+  type state = string list
+
+  let msg_handler state _ request =
+    let request = Util.Encoding.unpack bin_read_request request in
+    let response =
+      match request with
+      | Ping -> Pong
+      | Get -> List !state
+      | Insert s ->
+        state := s :: !state;
+        Success "Successfully added value to state" in
+    Util.Encoding.pack bin_writer_response response
+
+  (* Initializes four clients and the related four peers *)
+  let client_a =
+    Lwt_main.run (Client.init ~state:["test1"] ~msg_handler ("127.0.0.1", 3000))
+
+  let peer_a = Client.peer_from !client_a
+
+  let client_b =
+    Lwt_main.run (Client.init ~state:["test2"] ~msg_handler ("127.0.0.1", 3001))
+
+  let peer_b = Client.peer_from !client_b
+
+  let client_c =
+    Lwt_main.run (Client.init ~state:["test1"] ~msg_handler ("127.0.0.1", 3002))
+
+  let peer_c = Client.peer_from !client_c
+
+  let client_d =
+    Lwt_main.run (Client.init ~state:["test2"] ~msg_handler ("127.0.0.1", 3003))
+
+  let peer_d = Client.peer_from !client_d
+end

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,6 @@
 (tests
- (names pollinate_tests)
- (modules pollinate_tests)
+ (names client_tests)
+ (modules client_tests commons)
  (libraries pollinate bin_prot lwt alcotest-lwt)
  (preprocess
   (pps ppx_bin_prot lwt_ppx ppx_deriving.show)))


### PR DESCRIPTION
## Context

Some functions (like `Clients` and `Peers` definitions) are commons for the whole suite tests.
Extract every helper within a `commons.ml` module to ease the use of these functions and make the suite tests easier to read and maintain.