### PR TITLE
chore(renaming): switch suspicion and failure to fit the scope function

### DIFF
--- a/lib/node/failure_detector.ml
+++ b/lib/node/failure_detector.ml
@@ -154,7 +154,7 @@ let probe_peer t node peer_to_update =
       (* TODO: A `peer_to_update is suspect` message must be sent to every peers known by the node *)
       Lwt.return ())
 
-let failure_detection node =
+let suspicion_detection node =
   let open Peer in
   let t = !node.failure_detector in
   let available_peers =
@@ -174,7 +174,7 @@ let failure_detection node =
         ] in
     Lwt.return ()
 
-let suspicious_detection node =
+let failure_detection node =
   let open Peer in
   let t = !node.failure_detector in
   let timeout =

--- a/lib/node/failure_detector.mli
+++ b/lib/node/failure_detector.mli
@@ -16,11 +16,11 @@ val make : failure_detector_config -> failure_detector
 val handle_message : 'a node ref -> Message.t -> unit Lwt.t
 
 (** Responsible for the calculation of the status of each node *)
-val failure_detection : 'a node ref -> unit Lwt.t
+val suspicion_detection : 'a node ref -> unit Lwt.t
 
 (** If a peer is suspicious for more that failure_detector_config.suspicion_time
  it needs to be deleted from the list of knowns peers *)
-val suspicious_detection : 'a node ref -> unit Lwt.t
+val failure_detection : 'a node ref -> unit Lwt.t
 
 (**/**)
 

--- a/lib/node/server.ml
+++ b/lib/node/server.ml
@@ -32,8 +32,8 @@ let run node router msg_handler =
       | Some message -> Failure_detector.handle_message node message
       | None -> Lwt.return () in
 
+    let%lwt () = Failure_detector.suspicion_detection node in
     let%lwt () = Failure_detector.failure_detection node in
-    let%lwt () = Failure_detector.suspicious_detection node in
 
     let%lwt next_response = Inbox.next !node.inbox Message.Response in
     let _ = handle_response !node.request_table next_response in

--- a/test/failure_detector_tests.ml
+++ b/test/failure_detector_tests.ml
@@ -15,7 +15,7 @@ let node_b =
 
 let peer_b = Client.peer_from !node_b
 
-let suspicion_detection () =
+let failure_detection () =
   let open Common.Peer in
   let open Client in
   let _ = add_peer !node_a peer_b in
@@ -23,31 +23,31 @@ let suspicion_detection () =
   let _ = SUT.update_peer_status node_a peer_b Suspicious in
   (* Need to wait for the timeout to be reached An other way to do, would be to change the `last_suspicious_status` of the peer *)
   let%lwt _ = Lwt_unix.sleep 9.1 in
-  let%lwt _ = SUT.suspicious_detection node_a in
+  let%lwt _ = SUT.failure_detection node_a in
   Lwt.return (Base.Hashtbl.length !node_a.peers = 0)
 
-let suspicion_detection_nothing_on_alive () =
+let failure_detection_nothing_on_alive () =
   let open Common.Peer in
   let _ = add_neighbor (Pollinate.Node.Client.peer_from !node_a) peer_b in
   let _ = SUT.update_peer_status node_a peer_b Alive in
-  let%lwt _ = SUT.suspicious_detection node_a in
+  let%lwt _ = SUT.failure_detection node_a in
   Lwt.return (Base.Hashtbl.length !node_a.peers = 1)
 
 let test_suspicion_detection _ () =
-  suspicion_detection () >|= Alcotest.(check bool) "" true
+  failure_detection () >|= Alcotest.(check bool) "" true
 
-let test_suspicion_detection_nothing_on_alive _ () =
-  suspicion_detection_nothing_on_alive () >|= Alcotest.(check bool) "" true
+let test_failure_detection_nothing_on_alive _ () =
+  failure_detection_nothing_on_alive () >|= Alcotest.(check bool) "" true
 
 let () =
   Lwt_main.run
-  @@ Alcotest_lwt.run "Suspicion detector"
+  @@ Alcotest_lwt.run "Failure detector"
        [
          ( "failure_detector.ml",
            [
              Alcotest_lwt.test_case "Remove Suspicious peer" `Quick
                test_suspicion_detection;
              Alcotest_lwt.test_case "Do nothing on Alive peer" `Quick
-               test_suspicion_detection_nothing_on_alive;
+               test_failure_detection_nothing_on_alive;
            ] );
        ]


### PR DESCRIPTION
@rosalogia naming was really bad.
The `failure_detection` function was simply detecting the `suspicion`! And the `suspicious_detector` was handling the `failure` case...