### PR TITLE
Acknowledgement system

### DIFF
--- a/lib/node/client.ml
+++ b/lib/node/client.ml
@@ -21,7 +21,7 @@ let add_peer_as_is node (peer : Peer.t) =
 
 let peers node = Base.Hashtbl.keys node.peers
 
-let create_request node recipient payload =
+let create_request node ?(request_ack=false) recipient payload =
   Mutex.with_lock !node.current_request_id (fun id ->
       id := !id + 1;
       Lwt.return
@@ -29,6 +29,7 @@ let create_request node recipient payload =
           {
             category = Message.Request;
             sub_category_opt = None;
+            request_ack;
             id = !id;
             timestamp = Unix.gettimeofday ();
             sender = !node.address;
@@ -36,11 +37,12 @@ let create_request node recipient payload =
             payload;
           })
 
-let create_response node request payload =
+let create_response node ?(request_ack=false) request payload =
   Message.
     {
       category = Message.Response;
       sub_category_opt = None;
+      request_ack;
       id = request.id;
       timestamp = Unix.gettimeofday ();
       sender = !node.address;
@@ -48,10 +50,11 @@ let create_response node request payload =
       payload;
     }
 
-let create_post node payload =
+let create_post node ?(request_ack=false) payload =
   Message.
     {
       category = Message.Post;
+      request_ack;
       id = -1;
       sub_category_opt = None;
       timestamp = Unix.gettimeofday ();
@@ -59,6 +62,19 @@ let create_post node payload =
       recipients = [];
       payload;
     }
+
+
+let create_ack node incoming_message =
+  Message.{
+    category = Message.Acknowledgment;
+    sub_category_opt = None;
+    request_ack = false;
+    id = -1;
+    timestamp = Unix.gettimeofday ();
+    sender = !node.address;
+    recipients = [incoming_message.sender];
+    payload = incoming_message |> Message.hash_of |> Bytes.of_string
+  }
 
 let request node request recipient =
   let%lwt message = create_request node recipient request in

--- a/lib/node/client.ml
+++ b/lib/node/client.ml
@@ -21,7 +21,7 @@ let add_peer_as_is node (peer : Peer.t) =
 
 let peers node = Base.Hashtbl.keys node.peers
 
-let create_request node ?(request_ack=false) recipient payload =
+let create_request node ?(request_ack = false) recipient payload =
   Mutex.with_lock !node.current_request_id (fun id ->
       id := !id + 1;
       Lwt.return
@@ -37,7 +37,7 @@ let create_request node ?(request_ack=false) recipient payload =
             payload;
           })
 
-let create_response node ?(request_ack=false) request payload =
+let create_response node ?(request_ack = false) request payload =
   Message.
     {
       category = Message.Response;
@@ -50,7 +50,7 @@ let create_response node ?(request_ack=false) request payload =
       payload;
     }
 
-let create_post node ?(request_ack=false) payload =
+let create_post node ?(request_ack = false) payload =
   Message.
     {
       category = Message.Post;
@@ -63,18 +63,18 @@ let create_post node ?(request_ack=false) payload =
       payload;
     }
 
-
 let create_ack node incoming_message =
-  Message.{
-    category = Message.Acknowledgment;
-    sub_category_opt = None;
-    request_ack = false;
-    id = -1;
-    timestamp = Unix.gettimeofday ();
-    sender = !node.address;
-    recipients = [incoming_message.sender];
-    payload = incoming_message |> Message.hash_of |> Bytes.of_string
-  }
+  Message.
+    {
+      category = Message.Acknowledgment;
+      sub_category_opt = None;
+      request_ack = false;
+      id = -1;
+      timestamp = Unix.gettimeofday ();
+      sender = !node.address;
+      recipients = [incoming_message.sender];
+      payload = incoming_message |> Message.hash_of |> Bytes.of_string;
+    }
 
 let request node request recipient =
   let%lwt message = create_request node recipient request in

--- a/lib/node/client.mli
+++ b/lib/node/client.mli
@@ -28,14 +28,6 @@ val post : node ref -> Message.t -> unit
     entire network. *)
 val post : node ref -> Message.t -> unit
 
-(** Begins disseminating an encoded message meant to be witnessed by the
-    entire network. *)
-val post : node ref -> Message.t -> unit
-
-(** Begins disseminating an encoded message meant to be witnessed by the
-    entire network. *)
-val post : node ref -> Message.t -> unit
-
 (** [create_request node recipient payload] creates a [Message.t] of the {i Request category}
 addressed to {i recipient} containing {i payload}. *)
 val create_request : node ref -> Address.t -> bytes -> Message.t Lwt.t

--- a/lib/node/client.mli
+++ b/lib/node/client.mli
@@ -24,10 +24,6 @@ val peers : node -> Address.t list
     entire network. *)
 val post : node ref -> Message.t -> unit
 
-(** Begins disseminating an encoded message meant to be witnessed by the
-    entire network. *)
-val post : node ref -> Message.t -> unit
-
 (** [create_request node recipient payload] creates a [Message.t] of the {i Request category}
 addressed to {i recipient} containing {i payload}. *)
 val create_request :

--- a/lib/node/client.mli
+++ b/lib/node/client.mli
@@ -32,8 +32,8 @@ val post : node ref -> Message.t -> unit
     entire network. *)
 val post : node ref -> Message.t -> unit
 
-(** Begins disseminating an encoded message meant to be witnessed by as many
-    nodes in the network as possible. *)
+(** Begins disseminating an encoded message meant to be witnessed by the
+    entire network. *)
 val post : node ref -> Message.t -> unit
 
 (** [create_request node recipient payload] creates a [Message.t] of the {i Request category}

--- a/lib/node/client.mli
+++ b/lib/node/client.mli
@@ -30,11 +30,11 @@ val post : node ref -> Message.t -> unit
 
 (** [create_request node recipient payload] creates a [Message.t] of the {i Request category}
 addressed to {i recipient} containing {i payload}. *)
-val create_request : node ref -> Address.t -> bytes -> Message.t Lwt.t
+val create_request : node ref -> ?request_ack:bool -> Address.t -> bytes -> Message.t Lwt.t
 
 (** [create_response node request payload] creates a [Message.t] of the {i Response category}
 that responds to {i request} whose content is {i payload}. *)
-val create_response : node ref -> Message.t -> bytes -> Message.t
+val create_response : node ref -> ?request_ack:bool -> Message.t -> bytes -> Message.t
 
 (** Sends an encoded {i request} to the specified peer and
 returns a promise holding the response from the peer. This
@@ -45,4 +45,6 @@ val request : node ref -> bytes -> Address.t -> Message.t Lwt.t
 (** [create_post node payload] creates a [Message.t] of the {i Post category}
     containing {i payload} for eventual gossip dissemination across the
     entire network. *)
-val create_post : node ref -> bytes -> Message.t
+val create_post : node ref -> ?request_ack:bool -> bytes -> Message.t
+
+val create_ack : node ref -> Message.t -> Message.t

--- a/lib/node/client.mli
+++ b/lib/node/client.mli
@@ -30,11 +30,13 @@ val post : node ref -> Message.t -> unit
 
 (** [create_request node recipient payload] creates a [Message.t] of the {i Request category}
 addressed to {i recipient} containing {i payload}. *)
-val create_request : node ref -> ?request_ack:bool -> Address.t -> bytes -> Message.t Lwt.t
+val create_request :
+  node ref -> ?request_ack:bool -> Address.t -> bytes -> Message.t Lwt.t
 
 (** [create_response node request payload] creates a [Message.t] of the {i Response category}
 that responds to {i request} whose content is {i payload}. *)
-val create_response : node ref -> ?request_ack:bool -> Message.t -> bytes -> Message.t
+val create_response :
+  node ref -> ?request_ack:bool -> Message.t -> bytes -> Message.t
 
 (** Sends an encoded {i request} to the specified peer and
 returns a promise holding the response from the peer. This

--- a/lib/node/client.mli
+++ b/lib/node/client.mli
@@ -32,6 +32,10 @@ val post : node ref -> Message.t -> unit
     entire network. *)
 val post : node ref -> Message.t -> unit
 
+(** Begins disseminating an encoded message meant to be witnessed by as many
+    nodes in the network as possible. *)
+val post : node ref -> Message.t -> unit
+
 (** [create_request node recipient payload] creates a [Message.t] of the {i Request category}
 addressed to {i recipient} containing {i payload}. *)
 val create_request : node ref -> Address.t -> bytes -> Message.t Lwt.t

--- a/lib/node/failure_detector.ml
+++ b/lib/node/failure_detector.ml
@@ -70,12 +70,12 @@ let send_message message node recipient =
   let message = create_message node message recipient in
   Networking.send_to node message
 
-let send_ping_to node peer = send_message Ping node peer
+let send_ping_to node peer = send_message Ping node [peer]
 
-let send_acknowledge_to node peer = send_message Acknowledge node peer
+let send_acknowledge_to node peer = send_message Acknowledge node [peer]
 
 let send_ping_request_to node (recipient : Peer.t) =
-  send_message (PingRequest recipient.address) node recipient
+  send_message (PingRequest recipient.address) node [recipient]
 
 let handle_message node message =
   let open Message in

--- a/lib/node/failure_detector.ml
+++ b/lib/node/failure_detector.ml
@@ -70,12 +70,12 @@ let send_message message node recipient =
   let message = create_message node message recipient in
   Networking.send_to node message
 
-let send_ping_to node peer = send_message Ping node [peer]
+let send_ping_to node peer = send_message Ping node peer
 
-let send_acknowledge_to node peer = send_message Acknowledge node [peer]
+let send_acknowledge_to node peer = send_message Acknowledge node peer
 
 let send_ping_request_to node (recipient : Peer.t) =
-  send_message (PingRequest recipient.address) node [recipient]
+  send_message (PingRequest recipient.address) node recipient
 
 let handle_message node message =
   let open Message in

--- a/lib/node/failure_detector.ml
+++ b/lib/node/failure_detector.ml
@@ -58,6 +58,7 @@ let create_message node message recipient =
   Message.
     {
       category = Failure_detection;
+      request_ack = false;
       sub_category_opt = None;
       id = -1;
       timestamp = Unix.gettimeofday ();

--- a/lib/node/message.ml
+++ b/lib/node/message.ml
@@ -3,6 +3,7 @@ open Bin_prot.Std
 
 type category =
   | Uncategorized
+  | Acknowledgment
   | Request
   | Response
   | Post
@@ -13,6 +14,7 @@ type category =
 type t = {
   category : category;
   sub_category_opt : (string * string) option;
+  request_ack : bool;
   id : int;
   timestamp : float;
   sender : Address.t;

--- a/lib/node/message.mli
+++ b/lib/node/message.mli
@@ -12,6 +12,7 @@ determining how they are stored and
 where they are handled. *)
 type category =
   | Uncategorized
+  | Acknowledgment
   | Request
   | Response
   | Post
@@ -24,6 +25,7 @@ processed by the node's message handler. *)
 type t = {
   category : category;
   sub_category_opt : (string * string) option;
+  request_ack : bool;
   id : int;
   timestamp : float;
   sender : Address.t;

--- a/lib/node/node.ml
+++ b/lib/node/node.ml
@@ -30,6 +30,7 @@ let init ?(init_peers = []) Address.{ address; port } =
               suspicion_time = 9;
               helpers_size = 3;
             };
+        acknowledgments = Hashtbl.create 20;
         peers;
         disseminator = Disseminator.create ~num_rounds:10 ~epoch_length:50.;
       } in
@@ -41,6 +42,7 @@ let run_server ?(preprocessor = fun m -> m) ~msg_handler node =
 let seen node message = Disseminator.seen !node.disseminator message
 
 module Testing = struct
+  module AddressSet = Types.AddressSet
   module Failure_detector = Failure_detector
   module Networking = Networking
   let broadcast_queue node = Disseminator.broadcast_queue !node.disseminator

--- a/lib/node/node.mli
+++ b/lib/node/node.mli
@@ -22,6 +22,7 @@ val run_server :
 val seen : t ref -> Message.t -> bool
 
 module Testing : sig
+  module AddressSet = Types.AddressSet
   module Failure_detector = Failure_detector
   module Networking = Networking
   val broadcast_queue : t ref -> Message.t list

--- a/lib/node/types.ml
+++ b/lib/node/types.ml
@@ -15,12 +15,15 @@ type failure_detector = {
   mutable sequence_number : int;
 }
 
+module AddressSet = Set.Make (Address)
+
 type node = {
   address : Address.t;
   current_request_id : int ref Mutex.t;
   request_table : (int, Message.t Lwt_condition.t) Hashtbl.t;
   socket : file_descr Mutex.t;
   failure_detector : failure_detector;
+  acknowledgments : (string, AddressSet.t) Hashtbl.t;
   peers : (Address.t, Peer.t) Base.Hashtbl.t;
   mutable disseminator : Disseminator.t;
 }

--- a/lib/node/types.mli
+++ b/lib/node/types.mli
@@ -36,6 +36,8 @@ type failure_detector = {
   mutable sequence_number : int;
 }
 
+module AddressSet : Set.S with type elt = Address.t
+
 (** Represents a node with some state in a peer-to-peer network *)
 type node = {
   address : Address.t;
@@ -54,6 +56,9 @@ type node = {
   (* Failure detection component ; runs automatically with the server and is responsible
      for automatically removing dead nodes from the peers table. *)
   failure_detector : failure_detector;
+  (* Hashtable mapping message hashes to
+     peers who have acknowledged the corresponding message. *)
+  acknowledgments : (string, AddressSet.t) Hashtbl.t;
   (* Hashtable mapping addresses to Peers with statuses according
      to the SWIM failure-detection protocol *)
   peers : (Address.t, Peer.t) Base.Hashtbl.t;

--- a/test/failure_detector_tests.ml
+++ b/test/failure_detector_tests.ml
@@ -5,6 +5,7 @@ module SUT = Pollinate.Node.Testing.Failure_detector
 
 let node_a =
   Lwt_main.run (Node.init Address.{ address = "127.0.0.1"; port = 3003 })
+
 let node_b =
   Lwt_main.run (Node.init Address.{ address = "127.0.0.1"; port = 3004 })
 

--- a/test/failure_detector_tests.ml
+++ b/test/failure_detector_tests.ml
@@ -5,7 +5,6 @@ module SUT = Pollinate.Node.Testing.Failure_detector
 
 let node_a =
   Lwt_main.run (Node.init Address.{ address = "127.0.0.1"; port = 3003 })
-
 let node_b =
   Lwt_main.run (Node.init Address.{ address = "127.0.0.1"; port = 3004 })
 


### PR DESCRIPTION
Adds optional acknowledgement to messages. Super simple: if a message is marked as requesting acknowledgment from those who receive it, then receivers will check this flag and be sure to send an Acknowledgment message containing the message's hash to the sender. The consumer can handle these messages as they'd like.